### PR TITLE
Feature/#4-userDao-refectoring1

### DIFF
--- a/src/main/java/me/learn/springnote/ver2/user/dao/DUserDao.java
+++ b/src/main/java/me/learn/springnote/ver2/user/dao/DUserDao.java
@@ -1,0 +1,12 @@
+package me.learn.springnote.ver2.user.dao;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class DUserDao extends UserDao{
+    @Override
+    public Connection getConnection() throws ClassNotFoundException, SQLException {
+        //DB 커넥션 생성 (D용 DB)
+        return null;
+    }
+}

--- a/src/main/java/me/learn/springnote/ver2/user/dao/NUserDao.java
+++ b/src/main/java/me/learn/springnote/ver2/user/dao/NUserDao.java
@@ -1,0 +1,23 @@
+package me.learn.springnote.ver2.user.dao;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class NUserDao extends UserDao{
+
+    /**
+     * getConnection에서 JDBC가 정의한 Connection 인터페이스를 구현한 Connection 객체를 생성 (팩토리 메서드 패턴)
+     * NUserDao와 DUserDao는 Connection 객체를 생성하는데 관심. (어떻게 만들지, 어떻게 connection 기능을 제공하는지)
+     * --팩토리 메서드 패턴 :서브 클래스에서 구체적인 오브젝트 생성 방법을 결정한다.
+     */
+    @Override
+    public Connection getConnection() throws ClassNotFoundException, SQLException {
+        //DB 커넥션 생성 (N용 DB)
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        Connection c = DriverManager.getConnection(
+                "jdbc:mysql://localhost/yoon", "yoon", "yoon"
+        );
+        return c;
+    }
+}

--- a/src/main/java/me/learn/springnote/ver2/user/dao/UserDao.java
+++ b/src/main/java/me/learn/springnote/ver2/user/dao/UserDao.java
@@ -10,7 +10,7 @@ import java.sql.*;
  *           3. 리소스의 반환
  * 기타 문제 : 예외 처리가 없음 (나중에 처리)
  */
-public class UserDao {
+public abstract class UserDao {
     public void add(User user) throws ClassNotFoundException, SQLException {
         Connection c = getConnection();
 
@@ -66,12 +66,10 @@ public class UserDao {
 
     /**
      * 중복 메소드 추출
+     * 상속을 통해 서브클래스에서 DB커넥션 연결을 선택하도록 한다. (템플릿 메소트 패턴)
+     * --템플릿 메소트 패턴 : 슈퍼클래스에서 기본적인 로직의 흐름을 만들고 기능의 일부를 추상메소드나
+     *                     오버라이딩 가능한 protected로 만들어 서브클래스에서 이런 메소드를 필요에 맞게 구현.
+     *
      */
-    private static Connection getConnection() throws ClassNotFoundException, SQLException {
-        Class.forName("com.mysql.cj.jdbc.Driver");
-        Connection c = DriverManager.getConnection(
-                "jdbc:mysql://localhost/yoon", "yoon", "yoon"
-        );
-        return c;
-    }
+    public abstract Connection getConnection() throws ClassNotFoundException, SQLException;
 }

--- a/src/main/java/me/learn/springnote/ver2/user/dao/UserDao.java
+++ b/src/main/java/me/learn/springnote/ver2/user/dao/UserDao.java
@@ -12,10 +12,7 @@ import java.sql.*;
  */
 public class UserDao {
     public void add(User user) throws ClassNotFoundException, SQLException {
-        Class.forName("com.mysql.cj.jdbc.Driver");
-        Connection c = DriverManager.getConnection(
-                "jdbc:mysql://localhost/yoon", "yoon", "yoon"
-        );
+        Connection c = getConnection();
 
         PreparedStatement ps = c.prepareStatement(
                 "insert into users(id, name, password) values(?,?,?)"
@@ -31,12 +28,8 @@ public class UserDao {
         c.close();
     }
 
-
     public User get(String id) throws ClassNotFoundException, SQLException {
-        Class.forName("com.mysql.cj.jdbc.Driver");
-        Connection c = DriverManager.getConnection(
-                "jdbc:mysql://localhost/yoon", "yoon", "yoon"
-        );
+        Connection c = getConnection();
 
         PreparedStatement ps = c.prepareStatement(
                 "select * from users where id = ?"
@@ -59,10 +52,7 @@ public class UserDao {
     }
 
     public void deleteAll() throws ClassNotFoundException, SQLException {
-        Class.forName("com.mysql.cj.jdbc.Driver");
-        Connection c = DriverManager.getConnection(
-                "jdbc:mysql://localhost/yoon", "yoon", "yoon"
-        );
+        Connection c = getConnection();
 
         PreparedStatement ps = c.prepareStatement(
                 "delete from users;"
@@ -72,5 +62,16 @@ public class UserDao {
 
         ps.close();
         c.close();
+    }
+
+    /**
+     * 중복 메소드 추출
+     */
+    private static Connection getConnection() throws ClassNotFoundException, SQLException {
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        Connection c = DriverManager.getConnection(
+                "jdbc:mysql://localhost/yoon", "yoon", "yoon"
+        );
+        return c;
     }
 }

--- a/src/main/java/me/learn/springnote/ver2/user/dao/UserDao.java
+++ b/src/main/java/me/learn/springnote/ver2/user/dao/UserDao.java
@@ -1,0 +1,76 @@
+package me.learn.springnote.ver2.user.dao;
+
+import me.learn.springnote.ver2.user.domain.User;
+
+import java.sql.*;
+
+/**
+ * 개선 목표 : 1. DB와 연결을 위한 커넥션 가져오기
+ *           2. DB에 보낼 sql 문장을 담을 statement를 만들고 실행 (바인딩과 실행도 분리할 수 있음)
+ *           3. 리소스의 반환
+ * 기타 문제 : 예외 처리가 없음 (나중에 처리)
+ */
+public class UserDao {
+    public void add(User user) throws ClassNotFoundException, SQLException {
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        Connection c = DriverManager.getConnection(
+                "jdbc:mysql://localhost/yoon", "yoon", "yoon"
+        );
+
+        PreparedStatement ps = c.prepareStatement(
+                "insert into users(id, name, password) values(?,?,?)"
+        );
+
+        ps.setString(1, user.getId());
+        ps.setString(2, user.getName());
+        ps.setString(3, user.getPassword());
+
+        ps.executeUpdate();
+
+        ps.close();
+        c.close();
+    }
+
+
+    public User get(String id) throws ClassNotFoundException, SQLException {
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        Connection c = DriverManager.getConnection(
+                "jdbc:mysql://localhost/yoon", "yoon", "yoon"
+        );
+
+        PreparedStatement ps = c.prepareStatement(
+                "select * from users where id = ?"
+        );
+        ps.setString(1, id);
+
+        ResultSet rs = ps.executeQuery();
+        rs.next();
+
+        User user = new User();
+        user.setId(rs.getString("id"));
+        user.setName(rs.getString("name"));
+        user.setPassword(rs.getString("password"));
+
+        rs.close();
+        ps.close();
+        c.close();
+
+        return user;
+    }
+
+    public void deleteAll() throws ClassNotFoundException, SQLException {
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        Connection c = DriverManager.getConnection(
+                "jdbc:mysql://localhost/yoon", "yoon", "yoon"
+        );
+
+        PreparedStatement ps = c.prepareStatement(
+                "delete from users;"
+        );
+
+        ps.executeUpdate();
+
+        ps.close();
+        c.close();
+    }
+}

--- a/src/main/java/me/learn/springnote/ver2/user/domain/User.java
+++ b/src/main/java/me/learn/springnote/ver2/user/domain/User.java
@@ -1,0 +1,31 @@
+package me.learn.springnote.ver2.user.domain;
+
+public class User {
+    String id;
+    String name;
+    String password;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/test/java/me/learn/springnote/ver2/user/dao/UserDaoTest.java
+++ b/src/test/java/me/learn/springnote/ver2/user/dao/UserDaoTest.java
@@ -1,7 +1,6 @@
 package me.learn.springnote.ver2.user.dao;
 
-import me.learn.springnote.ver1.user.dao.UserDao;
-import me.learn.springnote.ver1.user.domain.User;
+import me.learn.springnote.ver2.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +13,7 @@ class UserDaoTest {
     @DisplayName("유저 등록")
     void add_user() throws SQLException, ClassNotFoundException {
         //given
-        me.learn.springnote.ver1.user.dao.UserDao dao = new me.learn.springnote.ver1.user.dao.UserDao();
+        UserDao dao = new UserDao();
 
         //when
         User user = new User();
@@ -33,7 +32,7 @@ class UserDaoTest {
     @DisplayName("유저 조회")
     void select_user() throws SQLException, ClassNotFoundException {
         //given
-        me.learn.springnote.ver1.user.dao.UserDao dao = new UserDao();
+        UserDao dao = new UserDao();
 
         User user = new User();
         user.setId("buchonsi");

--- a/src/test/java/me/learn/springnote/ver2/user/dao/UserDaoTest.java
+++ b/src/test/java/me/learn/springnote/ver2/user/dao/UserDaoTest.java
@@ -13,7 +13,7 @@ class UserDaoTest {
     @DisplayName("유저 등록")
     void add_user() throws SQLException, ClassNotFoundException {
         //given
-        UserDao dao = new UserDao();
+        UserDao dao = new NUserDao();
 
         //when
         User user = new User();
@@ -32,7 +32,7 @@ class UserDaoTest {
     @DisplayName("유저 조회")
     void select_user() throws SQLException, ClassNotFoundException {
         //given
-        UserDao dao = new UserDao();
+        UserDao dao = new NUserDao();
 
         User user = new User();
         user.setId("buchonsi");

--- a/src/test/java/me/learn/springnote/ver2/user/dao/UserDaoTest.java
+++ b/src/test/java/me/learn/springnote/ver2/user/dao/UserDaoTest.java
@@ -1,0 +1,52 @@
+package me.learn.springnote.ver2.user.dao;
+
+import me.learn.springnote.ver1.user.dao.UserDao;
+import me.learn.springnote.ver1.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserDaoTest {
+    @Test
+    @DisplayName("유저 등록")
+    void add_user() throws SQLException, ClassNotFoundException {
+        //given
+        me.learn.springnote.ver1.user.dao.UserDao dao = new me.learn.springnote.ver1.user.dao.UserDao();
+
+        //when
+        User user = new User();
+        user.setId("buchonsi");
+        user.setName("yoon");
+        user.setPassword("yoon1");
+
+        dao.add(user);
+
+        //then
+        assertThat(user.getId()).isEqualTo("buchonsi");
+        dao.deleteAll();
+    }
+
+    @Test
+    @DisplayName("유저 조회")
+    void select_user() throws SQLException, ClassNotFoundException {
+        //given
+        me.learn.springnote.ver1.user.dao.UserDao dao = new UserDao();
+
+        User user = new User();
+        user.setId("buchonsi");
+        user.setName("yoon");
+        user.setPassword("yoon1");
+
+        dao.add(user);
+
+        //when
+        User findUser = dao.get("buchonsi");
+
+        //then
+        assertThat(findUser).usingRecursiveComparison().isEqualTo(user);
+        dao.deleteAll();
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
* issue :  https://github.com/buchonsi/spring_note/issues/4

## 변경 사항  
* [x] UserDao 커넥션 분리
  * [x] UserDao 추상클래스로 변경
  * [x] UserDao getConnection() 생성
  * [x] 상속클래스 NUserDao, DUserDao 생성 
* [x] UserDao 테스트 코드 

## 기타 사항
* 템플릿 메서드 패턴과 팩토리 메서드 패턴을 사용해서 커넥션 분리
* 문제점 : 상속을 사용한 점
   - 슈퍼 클래스의 변화가 서브 클래스에 영향을 많이 줌
   - 커넥션 기능만을 위해 상속을 사용 (NUserDao와 DUserDao는 다른기능을 위한 상속 추가가 안된다)
   - UserDao외의 Dao 생성시 계속 getConnection()을 만들어 줘야 한다.